### PR TITLE
enable building/pushing multiple image tags per Dockerfile

### DIFF
--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,8 +1,15 @@
 #!/bin/bash -xe
 DOCKER_PATH=$(echo $DOCKERFILE_PATH | sed -e 's/.*\///g')
 
+# loop over comma sepeated list of tags
+for tag in ${DOCKER_TAG//,/ }
+do
+    # build string for multiple tags
+    TAGS="$TAGS -t $DOCKER_REPO:$tag"
+done
+
 docker build \
     --build-arg "SOURCE_BRANCH=$SOURCE_BRANCH" \
     --build-arg "SOURCE_COMMIT=$SOURCE_COMMIT" \
-    -f $DOCKER_PATH \
-    -t $IMAGE_NAME ../
+    -f "$DOCKER_PATH" \
+    "$TAGS" ../


### PR DESCRIPTION
This change allows us to push multiple tags to https://hub.docker.com/r/target/flottbot without having to repeatedly build the image.

The modified Docker cloud configuration looks like:

![image](https://user-images.githubusercontent.com/8935518/45429087-2c3f4c80-b668-11e8-8a04-de7bf073af50.png)

This change means that on our next tag event will have the following images pushed:

- golang
- ruby
- latest
- `<tag number>`
- `golang-<tag number>`
- `ruby-<tag number>`