### PR TITLE
fix(slack): stop hardcoding user email domain

### DIFF
--- a/remote/slack/helper.go
+++ b/remote/slack/helper.go
@@ -44,9 +44,7 @@ func constructInteractiveComponentMessage(callback slack.AttachmentActionCallbac
 		ID:   callback.User.ID,
 		Name: callback.User.Name,
 		Profile: slack.UserProfile{
-			// Unfortunately, Slack's callback does not populate the User.Profile field which contains the user email
-			// TODO: find out a way (ideally without making a slack API call) to compose the user's email successfully
-			Email:     fmt.Sprintf("%s@target.com", callback.User.Name),
+			Email:     callback.User.Profile.Email,
 			FirstName: userNames[0],
 			LastName:  userNames[len(userNames)-1],
 		},


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

This change no longer means that we will be hardcoding user email to be `@target.com`. This could be considered a breaking change since users will need to update the application scoping to include emails.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
