### PR TITLE
Fix allow_usergroups for bots using Slack Events API

### DIFF
--- a/remote/slack/helper.go
+++ b/remote/slack/helper.go
@@ -383,7 +383,6 @@ func populateMessage(message models.Message, msgType models.MessageType, channel
 		message.Timestamp = timeStamp
 		message.ThreadTimestamp = threadTimestamp
 		message.BotMentioned = mentioned
-		message.Attributes["ws_token"] = bot.SlackWorkspaceToken
 
 		// If the message read was not a dm, get the name of the channel it came from
 		if msgType != models.MsgTypeDirect {
@@ -544,12 +543,12 @@ func send(api *slack.Client, message models.Message, bot *models.Bot) {
 
 // sendBackToOriginMessage - sends a message back to where it came from in Slack; this is pretty much a catch-all among the other send functions
 func sendBackToOriginMessage(api *slack.Client, message models.Message) error {
-	return sendMessage(api, message.IsEphemeral, message.ChannelID, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Attributes["ws_token"], message.Remotes.Slack.Attachments)
+	return sendMessage(api, message.IsEphemeral, message.ChannelID, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Remotes.Slack.Attachments)
 }
 
 // sendChannelMessage - sends a message to a Slack channel
 func sendChannelMessage(api *slack.Client, channel string, message models.Message) error {
-	return sendMessage(api, message.IsEphemeral, channel, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Attributes["ws_token"], message.Remotes.Slack.Attachments)
+	return sendMessage(api, message.IsEphemeral, channel, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Remotes.Slack.Attachments)
 }
 
 // sendDirectMessage - sends a message back to the user who dm'ed your bot
@@ -558,11 +557,11 @@ func sendDirectMessage(api *slack.Client, userID string, message models.Message)
 	if err != nil {
 		return err
 	}
-	return sendMessage(api, message.IsEphemeral, imChannelID, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Attributes["ws_token"], message.Remotes.Slack.Attachments)
+	return sendMessage(api, message.IsEphemeral, imChannelID, message.Vars["_user.id"], message.Output, message.ThreadTimestamp, message.Remotes.Slack.Attachments)
 }
 
 // sendMessage - does the final send to Slack; adds any Slack-specific message parameters to the message to be sent out
-func sendMessage(api *slack.Client, ephemeral bool, channel, userID, text, threadTimeStamp, wsToken string, attachments []slack.Attachment) error {
+func sendMessage(api *slack.Client, ephemeral bool, channel, userID, text, threadTimeStamp string, attachments []slack.Attachment) error {
 	// send ephemeral message is indicated
 	if ephemeral {
 		var opt slack.MsgOption

--- a/remote/slack/helper.go
+++ b/remote/slack/helper.go
@@ -358,7 +358,7 @@ func populateUserGroups(bot *models.Bot) {
 		wsAPI := slack.New(bot.SlackWorkspaceToken)
 		ugroups, err := wsAPI.GetUserGroups()
 		if err != nil {
-			bot.Log.Debugf("Unable to retrieve usergroups. Restricting to rules with allow_usergroups and/or ignore_usergroups. Error: %s", err.Error())
+			bot.Log.Debugf("Unable to retrieve usergroups. Restricting access to rules with allow_usergroups and/or ignore_usergroups. Error: %s", err.Error())
 			bot.Log.Debug("Please double-check your slack_workspace_token. Also, if you recently added the usergroup:read scope you might have to reinstall your app in the Slack UI at api.slack.com")
 		}
 		for _, usergroup := range ugroups {

--- a/remote/slack/helper.go
+++ b/remote/slack/helper.go
@@ -358,7 +358,7 @@ func populateUserGroups(bot *models.Bot) {
 		wsAPI := slack.New(bot.SlackWorkspaceToken)
 		ugroups, err := wsAPI.GetUserGroups()
 		if err != nil {
-			bot.Log.Debugf("Unable to retrieve usergroups: %s", err.Error())
+			bot.Log.Debugf("Unable to retrieve usergroups. Restricting to rules with allow_usergroups and/or ignore_usergroups. Error: %s", err.Error())
 			bot.Log.Debug("Please double-check your slack_workspace_token. Also, if you recently added the usergroup:read scope you might have to reinstall your app in the Slack UI at api.slack.com")
 		}
 		for _, usergroup := range ugroups {
@@ -367,6 +367,10 @@ func populateUserGroups(bot *models.Bot) {
 		// we don't need API anymore
 		wsAPI = nil
 		bot.UserGroups = userGroups
+	} else {
+		bot.Log.Debug("Limiting to usergroups only works if you register " +
+			"your bot as an app with Slack and set the 'slack_workspace_token' property. " +
+			"Restricting access to rules with 'allow_usergroups' and/or 'ignore_usergroups', please set 'slack_workspace_token'.")
 	}
 }
 


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

Make `allow_usergroups` work when using Slack Events API by calling same methods we do when connecting via RTM at startup, ie. caching of usergroups/users.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
