### PR TITLE
fix(acl): populate user and group info for events api

### DIFF
--- a/remote/slack/helper.go
+++ b/remote/slack/helper.go
@@ -444,6 +444,16 @@ func processInteractiveComponentRule(rule models.Rule, message *models.Message, 
 // readFromEventsAPI utilizes the Slack API client to read event-based messages.
 // This method of reading is preferred over the RTM method.
 func readFromEventsAPI(api *slack.Client, vToken string, inputMsgs chan<- models.Message, bot *models.Bot) {
+	// get the current users
+	su, err := getSlackUsers(api, models.Message{})
+	if err != nil {
+		bot.Log.Error(err)
+	}
+	// populate users
+	populateBotUsers(su, bot)
+	// populate user groups
+	populateUserGroups(bot)
+
 	// Create router for the events server
 	router := mux.NewRouter()
 


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

Properly sized version of #75 . We are currently only populating users/groups for RTM-only bots. Unfortunately this will decrease test coverage as none of the `/remote` code has tests at the moment. I have tested the fix in a test Slack workspace. Feel free to validate.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
