### PR TITLE
Improvements to argument processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# IntelliJ 
+.idea
+
 ### OSX ###
 *.DS_Store
 .AppleDouble

--- a/core/matcher.go
+++ b/core/matcher.go
@@ -88,12 +88,13 @@ func handleChatServiceRule(outputMsgs chan<- models.Message, message models.Mess
 		}
 
 		if hit {
-			bot.Log.Debugf("Found rule match '%s'", rule.Name)
+			bot.Log.Debugf("Found rule match '%s' for input '%s'", rule.Name, message.Input)
 			// Don't go through more rules if rule is matched
 			match, stopSearch = true, true
 			// Publish metric to prometheus - metricname will be combination of bot name and rule name
 			Prommetric(bot.Name+"-"+rule.Name, bot)
 			// Capture untouched user input
+
 			message.Vars["_raw_user_input"] = message.Input
 			// Do additional checks on the rule before running
 			if !isValidHitChatRule(&message, rule, processedInput, bot) {
@@ -163,7 +164,7 @@ func isValidHitChatRule(message *models.Message, rule models.Rule, processedInpu
 	// If this wasn't a 'hear' rule, handle the args
 	if rule.Hear == "" {
 		// Get all the args that the message sender supplied
-		args := utils.FindArgs(processedInput)
+		args := utils.RuleArgTokenizer(processedInput)
 		// Are we expecting a number of args but don't have as many as the rule defines? Send a helpful message
 		if len(rule.Args) > 0 && len(args) < len(rule.Args) {
 			msg := fmt.Sprintf("You might be missing an argument or two. This is what I'm looking for\n```%s```", rule.HelpText)

--- a/handlers/script.go
+++ b/handlers/script.go
@@ -30,13 +30,15 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 	defer cancel()
 
 	// Deal with variable substitution in command
+	bot.Log.Debugf("Command is: [%s]", args.Cmd)
 	cmdProcessed, err := utils.Substitute(args.Cmd, msg.Vars)
+	bot.Log.Debugf("Substituted: [%s]", cmdProcessed)
 	if err != nil {
 		return result, err
 	}
 
 	// Parse out all the arguments from the supplied command
-	bin := utils.FindArgs(cmdProcessed)
+	bin := utils.ExecArgTokenizer(cmdProcessed)
 	// Execute the command + arguments with the context
 	cmd := exec.CommandContext(ctx, bin[0], bin[1:]...)
 

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -67,8 +67,20 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 	return value, nil
 }
 
-// FindArgs goes through a string and tokenizes as parameters
-func FindArgs(stripped string) []string {
+// RuleArgTokenizer goes through a string and tokenizes as parameters for use when identifying rules to be triggered (ignoring empty arguments)
+func RuleArgTokenizer(stripped string) []string {
+	re := regexp.MustCompile(`["“]([^"“”]+)["”]|([^"“”\s]+)`)
+	argmatch := re.FindAllString(stripped, -1)
+
+	for i, arg := range argmatch {
+		argmatch[i] = strings.Trim(arg, `"“”`)
+	}
+
+	return argmatch
+}
+
+// ExecArgTokenizer goes through a string and tokenizes as parameters for use when executing a script (respecting empty arguments)
+func ExecArgTokenizer(stripped string) []string {
 	re := regexp.MustCompile(`('[^']*')|("[^"]*")|“([^”]*”)|([^'"“”\s]+)`)
 	argmatch := re.FindAllString(stripped, -1)
 

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -69,7 +69,7 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 
 // FindArgs goes through a string and tokenizes as parameters
 func FindArgs(stripped string) []string {
-	re := regexp.MustCompile(`["“]([^"“”]+)["”]|([^"“”\s]+)`)
+	re := regexp.MustCompile(`('')|("")|(“”)|("[^"]+")|(“([^”]+)”)|([^'"“”\s]+)`)
 	argmatch := re.FindAllString(stripped, -1)
 
 	for i, arg := range argmatch {

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -69,11 +69,11 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 
 // FindArgs goes through a string and tokenizes as parameters
 func FindArgs(stripped string) []string {
-	re := regexp.MustCompile(`('')|("")|(“”)|('[^']+')|("[^"]+")|(“([^”]+)”)|([^'"“”\s]+)`)
+	re := regexp.MustCompile(`('[^']*')|("[^"]*")|“([^”]*”)|([^'"“”\s]+)`)
 	argmatch := re.FindAllString(stripped, -1)
 
 	for i, arg := range argmatch {
-		argmatch[i] = strings.Trim(arg, `"“”`)
+		argmatch[i] = strings.Trim(arg, `'"“”`)
 	}
 
 	return argmatch

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -69,7 +69,7 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 
 // FindArgs goes through a string and tokenizes as parameters
 func FindArgs(stripped string) []string {
-	re := regexp.MustCompile(`('')|("")|(“”)|("[^"]+")|(“([^”]+)”)|([^'"“”\s]+)`)
+	re := regexp.MustCompile(`('')|("")|(“”)|('[^']+')|("[^"]+")|(“([^”]+)”)|([^'"“”\s]+)`)
 	argmatch := re.FindAllString(stripped, -1)
 
 	for i, arg := range argmatch {

--- a/utils/parse_test.go
+++ b/utils/parse_test.go
@@ -141,7 +141,7 @@ func TestExecArgTokenizer(t *testing.T) {
 		{"Multiple, Quoted (Mismatched Quotes, Double/Single)", args{stripped: `one two "quoted arg' three`}, []string{"one", "two", "quoted", "arg", "three"}},
 		{"Multiple, Quoted (Mismatched Quotes, Smart Close/Single)", args{stripped: `one two ”quoted arg' three`}, []string{"one", "two", "quoted", "arg", "three"}},
 		{"Multiple, Quoted (Mismatched Quotes, Smart Open/Single)", args{stripped: `one two “quoted arg' three`}, []string{"one", "two", "quoted", "arg", "three"}},
-		{"Multiple, Quoted (Mismatched Quotes, Smart Close/Double)", args{stripped: `one two ”quoted arg " three`}, []string{"one", "two", "quoted", "arg", "three"}},
+		{"Multiple, Quoted (Mismatched Quotes, Smart Close/Double)", args{stripped: `one two ”quoted arg" three`}, []string{"one", "two", "quoted", "arg", "three"}},
 		{"Multiple, Quoted (Mismatched Quotes, Smart Open/Double)", args{stripped: `one two “quoted arg" three`}, []string{"one", "two", "quoted", "arg", "three"}},
 		{"Multiple, Quoted (Mismatched Quotes, Smart Close/Smart Close)", args{stripped: `one two ”quoted arg” three`}, []string{"one", "two", "quoted", "arg", "three"}},
 		{"Multiple, Quoted (Mismatched Quotes, Smart Open/Smart Open)", args{stripped: `one two “quoted arg“ three`}, []string{"one", "two", "quoted", "arg", "three"}},


### PR DESCRIPTION
## Proposed change

This PR fixes a bug in `utils.parse.FindArgs`.   `FindArgs` doesn’t properly handle the case where there is an empty quoted argument, like when a variable is empty.  

For example, our rules file might have a command like this:

```yaml
cmd: '/usr/bin/whatever "${_user.id}" "${_user.email}" "${_user.firstname}" "${_user.lastname}" "${_channel.id}" "${_channel.name}" "${_raw_user_input}"'
```

When someone interacts with the bot in a channel, the generated command looks something like this:

```sh
/usr/bin/whatever "userid" "email@domain" "First" "Last" "channelid" "channelname" "string of words"
```

However, when someone interacts with the bot in the **Apps** section of Slack, there is no channel name, so `${_channel.name}` is empty.  Under those circumstances, the generated command looks like this:

```sh
/usr/bin/whatever "userid" "email@domain" "First" "Last" "channelid" "" "string of words"
```

The current regular expression gets confused by the empty `""`.  As a result, the arguments passed to the script actually end up being:

```
"userid" "email@domain" "First" "Last" " " "string" "of" "words"
```

The modified regular expression resolves this problem by explicitly allowing empty arguments with 3 types of quotes.

The new regular expression also tightens up the match so that only pairs of the same quote character are valid.  For instance, `'whatever"` is not considered a quoted argument, since it's not valid shell syntax.   Only `'whatever'`, `"whatever"`, etc. match.  

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I have added unit tests, and also tested manually through the CLI interface.  I also manually verified that the regular expression works through interactive testing on regex101.com.