### PR TITLE
fix(discord): populate message with author user info instead of bot info

### DIFF
--- a/remote/discord/remote.go
+++ b/remote/discord/remote.go
@@ -53,12 +53,12 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 	bot.Log.Infof("Discord is now running '%s'. Press CTRL-C to exit", bot.Name)
 
 	// get informatiom about ourself
-	user, err := dg.User("@me")
+	botuser, err := dg.User("@me")
 	if err != nil {
 		bot.Log.Errorf("Failed to get bot name from Discord. Error: %s", err.Error())
 		return
 	}
-	bot.Name = user.Username
+	bot.Name = botuser.Username
 
 	// Register a callback for MessageCreate events
 	dg.AddHandler(handleDiscordMessage(bot, inputMsgs))
@@ -121,7 +121,7 @@ func handleDiscordMessage(bot *models.Bot, inputMsgs chan<- models.Message) inte
 				bot.Log.Debugf("Discord Remote: read message from unsupported channel type '%d'. Defaulting to use channel type 0 ('GUILD_TEXT')", ch.Type)
 			}
 			contents, mentioned := removeBotMention(m.Content, s.State.User.ID)
-			message = populateMessage(message, msgType, m.ChannelID, contents, timestamp, mentioned, s.State.User, bot)
+			message = populateMessage(message, msgType, m.ChannelID, contents, timestamp, mentioned, m.Author, bot)
 		default:
 			bot.Log.Errorf("Discord Remote: read message of unsupported type '%d'. Unable to populate message attributes", m.Type)
 		}


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

Currently, the discord output vars of`message.Vars["_user.email"]`, `message.Vars["_user.name"]`, and `message.Vars["_user.id"]` is being populated with the bot information instead of the user that originated the message. This PR does a simple fix to correctly utilize the user that originated the message.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
