### PR TITLE
feat(discord): add reaction support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,12 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:4fd5ce7844c22e194005b9e12fee8adc70fb5ba0bbba9e1964d2e3d1f301d789"
+  digest = "1:fc4f149402c1fa7258290c3f91b0bfbc709763f3d3899609a2e4a0163dec65c6"
   name = "github.com/bwmarrin/discordgo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4a33b9bc7c56cfdb9bb244e33e83cb3941fe2bdc"
-  version = "v0.18.0"
+  revision = "8325a6bf6dd6c91ed4040a1617b07287b8fb0eba"
+  version = "v0.19.0"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -66,7 +66,7 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
+  digest = "1:0c6aceca32885ed17808af2ad3a85f2cf18aca1a49b25de4a1d54f03913128c0"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -133,7 +133,7 @@
   revision = "c48cc78d482608239f6c4c92a4abd87eb8761c90"
 
 [[projects]]
-  digest = "1:0d01bcdbda5760553e5ab803faa3d3a0dc6a3ef357eb179b8ac8501b358d49ce"
+  digest = "1:41c243b749b02670f87f849c205954af71f08d4ba8a0252a6c93128e692a6e3c"
   name = "github.com/nlopes/slack"
   packages = [
     ".",
@@ -170,7 +170,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  digest = "1:0f37e09b3e92aaeda5991581311f8dbf38944b36a3edec61cc2d1991f527554a"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "UT"
@@ -178,7 +178,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:63b68062b8968092eb86bedc4e68894bd096ea6b24920faca8b9dcf451f54bb5"
+  digest = "1:dad2e5a2153ee7a6c9ab8fc13673a16ee4fb64434a7da980965a3741b0c981a3"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -190,7 +190,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ef74914912f99c79434d9c09658274678bc85080ebe3ab32bec3940ebce5e1fc"
+  digest = "1:4f63dbf446cdeef6226bffe9bbc5fc8b93e13378f84833fb4306514411a76963"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -226,7 +226,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:6a4a11ba764a56d2758899ec6f3848d24698d48442ebce85ee7a3f63284526cd"
+  digest = "1:7f665ff60a4c8efd5a5c053bf862020cf9f7cd56c3f70dd140f45cd66fb08a8d"
   name = "github.com/spf13/afero"
   packages = [
     ".",
@@ -270,7 +270,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:207d2e280e7a43845b12d07437538d22d02dbd4c274b49f3940bb3dce2ed70d7"
+  digest = "1:a6c91777916f37c288a9f2e352feb7567c3ff4c47a3880b391070740d3357e4f"
   name = "golang.org/x/crypto"
   packages = [
     "internal/subtle",
@@ -284,7 +284,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:850d28ab022512e2cd3cf511a77f363c29e22689b4031f2050871f5de47ae4a0"
+  digest = "1:19b2eb89a60dafcfe5c699fa21ef51143d9bc4825c155608f81e56e0a9a4bba4"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -294,7 +294,7 @@
   revision = "4497e2df6f9e69048a54498c7affbbec3294ad47"
 
 [[projects]]
-  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
+  digest = "1:038003d098ffc345c4c5c6d47bcc6920b2649ee0c0d557162e54e75c76cadf8b"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/bwmarrin/discordgo"
-  version = "0.18.0"
+  version = "0.19.0"
 
 [[constraint]]
   name = "github.com/gorilla/mux"

--- a/core/outputs.go
+++ b/core/outputs.go
@@ -29,6 +29,7 @@ func Outputs(outputMsgs <-chan models.Message, hitRule <-chan models.Rule, bot *
 					break
 				}
 				remoteDiscord = &discord.Client{Token: bot.DiscordToken}
+				remoteDiscord.Reaction(message, rule, bot)
 				remoteDiscord.Send(message, bot)
 			case "slack":
 				// Create Slack client

--- a/handlers/script.go
+++ b/handlers/script.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -60,6 +61,10 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 			bot.Log.Debugf("Process for action '%s' exited with status %d: %s", args.Name, ws.ExitStatus(), stderr)
 			result.Status = ws.ExitStatus()
 			result.Output = stderr
+		case *os.PathError:
+			result.Status = 127
+			bot.Log.Debugf("Process for action '%s' exited with status %d: %s", args.Name, result.Status, err)
+			result.Output = err.Error()
 		default:
 			// this should rarely/never get hit
 			bot.Log.Debugf("Couldn't get exit status for action '%s'", args.Name)

--- a/handlers/script.go
+++ b/handlers/script.go
@@ -62,8 +62,8 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 			result.Status = ws.ExitStatus()
 			result.Output = stderr
 		case *os.PathError:
-			result.Status = 127
 			bot.Log.Debugf("Process for action '%s' exited with status %d: %s", args.Name, result.Status, err)
+			result.Status = 127
 			result.Output = err.Error()
 		default:
 			// this should rarely/never get hit

--- a/remote/discord/helper.go
+++ b/remote/discord/helper.go
@@ -12,7 +12,7 @@ Discord helper functions (anything that uses the discord package)
 */
 
 // populateMessage - populates the 'Message' object to be passed on for processing/sending
-func populateMessage(message models.Message, msgType models.MessageType, channel, text, timeStamp string, mentioned bool, user *discordgo.User, bot *models.Bot) models.Message {
+func populateMessage(message models.Message, msgType models.MessageType, channel, id string, text, timeStamp string, mentioned bool, user *discordgo.User, bot *models.Bot) models.Message {
 	// Populate message attributes
 	message.Type = msgType
 	message.Service = models.MsgServiceChat
@@ -21,6 +21,7 @@ func populateMessage(message models.Message, msgType models.MessageType, channel
 	message.Output = ""
 	message.Timestamp = timeStamp
 	message.BotMentioned = mentioned
+	message.ID = id
 
 	// if msgType != models.MsgTypeDirect {
 	// 	name, ok := findKey(bot.Rooms, channel)

--- a/remote/slack/remote.go
+++ b/remote/slack/remote.go
@@ -38,7 +38,7 @@ func (c *Client) Reaction(message models.Message, rule models.Rule, bot *models.
 		api := c.new()
 		// Grab a reference to the message
 		msgRef := slack.NewRefToMessage(message.ChannelID, message.Timestamp)
-		// React with desired reaction
+		// Remove bot reaction from message
 		if err := api.RemoveReaction(rule.RemoveReaction, msgRef); err != nil {
 			bot.Log.Errorf("Could not add reaction '%s'", err)
 			return


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

This PR adds reaction functionality to the Discord remote. I'll note to fully achieve this functionality I needed to add the initiating message id to the message struct, since Discord doesn't have the similar functionality of https://github.com/target/flottbot/blob/9213a3f74f9d0b80b9cd730258545cd61a12d886/remote/slack/remote.go#L40 to determine the message id.

I also updated dependent packages and update the slack reaction comments.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
