### PR TITLE
feat!: run flottbot as unprivileged user in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     -o flottbot ./cmd/flottbot
 
 FROM alpine:3.11
-RUN apk --no-cache add ca-certificates && mkdir config
+ENV USERNAME=flottbot
+ENV UID=900
+RUN apk --no-cache add ca-certificates && mkdir config && adduser -S --u "$UID" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 3000 4000 8080
 
+USER ${USERNAME}
 CMD [ "/flottbot" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 FROM alpine:3.11
 ENV USERNAME=flottbot
+ENV GROUP=flottbot
 ENV UID=900
-RUN apk --no-cache add ca-certificates && mkdir config && adduser -S --u "$UID" "$USERNAME"
+ENV GID=900
+RUN apk --no-cache add ca-certificates && mkdir config && \
+  addgroup -g "$GID" -S "$GROUP" && adduser -S -u "$UID" -G "$GROUP" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 3000 4000 8080

--- a/docker/Dockerfile.golang
+++ b/docker/Dockerfile.golang
@@ -16,9 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     -o flottbot ./cmd/flottbot
 
 FROM golang:1.14-alpine
-RUN apk --no-cache add ca-certificates && mkdir config
+ENV USERNAME=flottbot
+ENV UID=900
+RUN apk --no-cache add ca-certificates && mkdir config && adduser -S -u "$UID" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 3000 4000 8080
 
+USER ${USERNAME}
 CMD [ "/flottbot" ]

--- a/docker/Dockerfile.golang
+++ b/docker/Dockerfile.golang
@@ -17,8 +17,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 FROM golang:1.14-alpine
 ENV USERNAME=flottbot
+ENV GROUP=flottbot
 ENV UID=900
-RUN apk --no-cache add ca-certificates && mkdir config && adduser -S -u "$UID" "$USERNAME"
+ENV GID=900
+RUN apk --no-cache add ca-certificates && mkdir config && \
+  addgroup -g "$GID" -S "$GROUP" && adduser -S -u "$UID" -G "$GROUP" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 3000 4000 8080

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -16,9 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     -o flottbot ./cmd/flottbot
 
 FROM python:3-alpine
-RUN apk --no-cache add ca-certificates && mkdir config
+ENV USERNAME=flottbot
+ENV UID=900
+RUN apk --no-cache add ca-certificates && mkdir config && adduser -S -u "$UID" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 8080 3000 4000
 
+USER ${USERNAME}
 CMD ["/flottbot"]

--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -17,8 +17,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 FROM python:3-alpine
 ENV USERNAME=flottbot
+ENV GROUP=flottbot
 ENV UID=900
-RUN apk --no-cache add ca-certificates && mkdir config && adduser -S -u "$UID" "$USERNAME"
+ENV GID=900
+RUN apk --no-cache add ca-certificates && mkdir config && \
+  addgroup -g "$GID" -S "$GROUP" && adduser -S -u "$UID" -G "$GROUP" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 8080 3000 4000

--- a/docker/Dockerfile.ruby
+++ b/docker/Dockerfile.ruby
@@ -16,9 +16,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     -o flottbot ./cmd/flottbot
 
 FROM ruby:2.7-alpine
-RUN apk add --no-cache ca-certificates ruby-dev build-base && mkdir config
+ENV USERNAME=flottbot
+ENV UID=900
+RUN apk add --no-cache ca-certificates ruby-dev build-base && mkdir config && adduser -S -u "$UID" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 8080 3000 4000
 
+USER ${USERNAME}
 CMD ["/flottbot"]

--- a/docker/Dockerfile.ruby
+++ b/docker/Dockerfile.ruby
@@ -17,8 +17,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 FROM ruby:2.7-alpine
 ENV USERNAME=flottbot
+ENV GROUP=flottbot
 ENV UID=900
-RUN apk add --no-cache ca-certificates ruby-dev build-base && mkdir config && adduser -S -u "$UID" "$USERNAME"
+ENV GID=900
+RUN apk add --no-cache ca-certificates ruby-dev build-base && mkdir config &&  \
+  addgroup -g "$GID" -S "$GROUP" && adduser -S -u "$UID" -G "$GROUP" "$USERNAME"
 COPY --from=build /src/flottbot /flottbot
 
 EXPOSE 8080 3000 4000


### PR DESCRIPTION
## Proposed change

Runs flottbot as an unprivileged user rather than root in the docker
images. Adds flottbot as a system user with uid 900 by default but allows
setting those values as env vars and set the image to use that user at
runtime.

It doesn't seem necessary to run flottbot as root and my testing with docker images built in this way hasn't shown any issues. It would seem sensible to limit privilege for a service that's going to be exposed to the net.

Currently the changes create the 'flottbot' user with an arbitrary UID of 900. This is configurable by setting ENV in the the Dockerfile. I'm not totally sure what the best way of deciding what UID to use is, but I guess picking a value and documenting it is probably reasonable - otherwise it's a case of just doing useradd and getting a value that can change each build.

I've marked this a a breaking change as it's possible users may have config files that are not readable by the new user. Potentially we'd need to add some documentation about this - happy to do that if the change seems reasonable in principle. 

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
