### PR TITLE
feat: respond to bots

### DIFF
--- a/models/bot.go
+++ b/models/bot.go
@@ -29,6 +29,7 @@ type Bot struct {
 	Metrics                       bool              `mapstructure:"metrics,omitempty"`
 	CustomHelpText                string            `mapstructure:"custom_help_text,omitempty"`
 	DisableNoMatchHelp            bool              `mapstructure:"disable_no_match_help,omitempty"`
+	RespondToBots                 bool              `mapstructure:"respond_to_bots,omitempty"`
 	// System
 	Log          logrus.Logger
 	RunChat      bool

--- a/remote/discord/remote.go
+++ b/remote/discord/remote.go
@@ -172,9 +172,8 @@ func (c *Client) InteractiveComponents(inputMsgs chan<- models.Message, message 
 // message is created on any channel that the authenticated bot has access to
 func handleDiscordMessage(bot *models.Bot, inputMsgs chan<- models.Message) interface{} {
 	return func(s *discordgo.Session, m *discordgo.MessageCreate) {
-		// Ignore all messages created by bots
-		// This isn't required in this specific example but it's a good practice
-		if m.Author.Bot {
+		// check if we should respond to bot messages
+		if m.Author.Bot && !bot.RespondToBots {
 			return
 		}
 

--- a/remote/telegram/remote.go
+++ b/remote/telegram/remote.go
@@ -68,40 +68,48 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 			continue
 		}
 
-		msg, mentioned := processMessageText(m.Text, bot.Name)
-
-		// support slash commands
-		if len(m.Command()) > 0 {
-			fullCmd := fmt.Sprintf("%s %s", m.Command(), m.CommandArguments())
-			mentioned = true
-			msg = strings.TrimSpace(fullCmd)
+		// check if we should respond to other bot messages
+		if m.From.IsBot && !bot.RespondToBots {
+			continue
 		}
 
-		message := models.NewMessage()
-		message.Timestamp = strconv.FormatInt(m.Time().Unix(), 10)
-		message.Type = mapMessageType(*m)
-		message.Input = msg
-		message.Output = ""
-		message.ID = strconv.Itoa(m.MessageID)
-		message.Service = models.MsgServiceChat
-		message.BotMentioned = mentioned
-		message.ChannelID = strconv.FormatInt(m.Chat.ID, 10)
+		// only process messages not from out bot
+		if m.From.ID != botuser.ID {
+			msg, mentioned := processMessageText(m.Text, bot.Name)
 
-		// populate message with metadata
-		if m.From != nil {
-			message.Vars["_user.name"] = m.From.UserName
-			message.Vars["_user.firstname"] = m.From.FirstName
-			message.Vars["_user.lastname"] = m.From.LastName
-			message.Vars["_user.id"] = strconv.Itoa(m.From.ID)
-			message.Vars["_user.realnamenormalized"] = fmt.Sprintf("%s %s", m.From.FirstName, m.From.LastName)
-			message.Vars["_user.displayname"] = m.From.UserName
-			message.Vars["_user.displaynamenormalized"] = m.From.UserName
+			// support slash commands
+			if len(m.Command()) > 0 {
+				fullCmd := fmt.Sprintf("%s %s", m.Command(), m.CommandArguments())
+				mentioned = true
+				msg = strings.TrimSpace(fullCmd)
+			}
+
+			message := models.NewMessage()
+			message.Timestamp = strconv.FormatInt(m.Time().Unix(), 10)
+			message.Type = mapMessageType(*m)
+			message.Input = msg
+			message.Output = ""
+			message.ID = strconv.Itoa(m.MessageID)
+			message.Service = models.MsgServiceChat
+			message.BotMentioned = mentioned
+			message.ChannelID = strconv.FormatInt(m.Chat.ID, 10)
+
+			// populate message with metadata
+			if m.From != nil {
+				message.Vars["_user.name"] = m.From.UserName
+				message.Vars["_user.firstname"] = m.From.FirstName
+				message.Vars["_user.lastname"] = m.From.LastName
+				message.Vars["_user.id"] = strconv.Itoa(m.From.ID)
+				message.Vars["_user.realnamenormalized"] = fmt.Sprintf("%s %s", m.From.FirstName, m.From.LastName)
+				message.Vars["_user.displayname"] = m.From.UserName
+				message.Vars["_user.displaynamenormalized"] = m.From.UserName
+			}
+
+			message.Vars["_channel.id"] = message.ChannelID
+			message.Vars["_channel.name"] = m.Chat.Title
+
+			inputMsgs <- message
 		}
-
-		message.Vars["_channel.id"] = message.ChannelID
-		message.Vars["_channel.name"] = m.Chat.Title
-
-		inputMsgs <- message
 	}
 }
 


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

adds global `respond_to_bot` setting to allow your bot to consider messages originating from other bots for matching. it generally frowned upon to respond to other bots, so `false` is the default. more granular control at a rule level may be introduced later. it looks like this was default behavior for the current Telegram integration.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
