### PR TITLE
fix(makefile): fix up inference of GOPATH in validate task for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ getdeps:
 	@which golangci-lint 1>/dev/null || \
 		(echo "Installing golangci-lint" && \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-		sh -s -- -b $(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION))
+		sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_LINT_VERSION))
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Previously the attempt at deriving GOPATH in the Makefile validate task
would error out because a shell instruction for the Makefile was
missing. This was probably a just a syntax snafu converting from shell
to Make.

Fixes #198


### ❤ THANKS FOR HELPING OUT :D

## Proposed change

Describe your change and communicate why we should accept the pull request. Links to issues are helpful too, if applicable.

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)