### PR TITLE
refactor(log): detach logger from Bot

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,6 @@
             "request": "launch",
             "mode": "exec",
             "remotePath": "",
-            "port": 2345,
             "host": "127.0.0.1",
             "program": "${workspaceRoot}/debug",
             "preLaunchTask": "build-debug",

--- a/core/configure_test.go
+++ b/core/configure_test.go
@@ -1,35 +1,10 @@
 package core
 
 import (
-	"os"
 	"testing"
 
 	"github.com/target/flottbot/models"
 )
-
-func TestInitLogger(t *testing.T) {
-	type args struct {
-		bot *models.Bot
-	}
-
-	// Test setting the error and debug level flags
-	levelTests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{"error level set", args{bot: &models.Bot{}}, "info"},
-		{"debug level set", args{bot: &models.Bot{Debug: true}}, "debug"},
-	}
-	for _, tt := range levelTests {
-		t.Run(tt.name, func(t *testing.T) {
-			initLogger(tt.args.bot)
-			if tt.want != tt.args.bot.Log.GetLevel().String() {
-				t.Errorf("initLogger() wanted level set at '%s', but got '%s'", tt.want, tt.args.bot.Log.GetLevel().String())
-			}
-		})
-	}
-}
 
 func Test_configureChatApplication(t *testing.T) {
 	type args struct {
@@ -79,8 +54,8 @@ func Test_configureChatApplication(t *testing.T) {
 	testBotSlack.ChatApplication = "slack"
 	testBotSlack.SlackToken = "${TEST_SLACK_TOKEN}"
 	testBotSlack.SlackAppToken = "${TEST_SLACK_APP_TOKEN}"
-	os.Setenv("TEST_SLACK_TOKEN", "TESTTOKEN")
-	os.Setenv("TEST_SLACK_APP_TOKEN", "TESTAPPTOKEN")
+	t.Setenv("TEST_SLACK_TOKEN", "TESTTOKEN")
+	t.Setenv("TEST_SLACK_APP_TOKEN", "TESTAPPTOKEN")
 	validateRemoteSetup(testBotSlack)
 
 	testBotDiscordNoToken := new(models.Bot)
@@ -99,8 +74,8 @@ func Test_configureChatApplication(t *testing.T) {
 	testBotDiscordServerID.ChatApplication = "discord"
 	testBotDiscordServerID.DiscordToken = "${TEST_DISCORD_TOKEN}"
 	testBotDiscordServerID.DiscordServerID = "${TEST_DISCORD_SERVER_ID}"
-	os.Setenv("TEST_DISCORD_TOKEN", "TESTTOKEN")
-	os.Setenv("TEST_DISCORD_SERVER_ID", "TESTSERVERID")
+	t.Setenv("TEST_DISCORD_TOKEN", "TESTTOKEN")
+	t.Setenv("TEST_DISCORD_SERVER_ID", "TESTSERVERID")
 	validateRemoteSetup(testBotDiscordServerID)
 
 	testBotDiscordBadServerID := new(models.Bot)
@@ -114,7 +89,7 @@ func Test_configureChatApplication(t *testing.T) {
 	testBotTelegram.CLI = true
 	testBotTelegram.ChatApplication = "telegram"
 	testBotTelegram.TelegramToken = "${TEST_TELEGRAM_TOKEN}"
-	os.Setenv("TEST_TELEGRAM_TOKEN", "TESTTOKEN")
+	t.Setenv("TEST_TELEGRAM_TOKEN", "TESTTOKEN")
 	validateRemoteSetup(testBotTelegram)
 
 	testBotTelegramNoToken := new(models.Bot)
@@ -162,15 +137,11 @@ func Test_configureChatApplication(t *testing.T) {
 			}
 		})
 	}
-
-	os.Unsetenv("TEST_SLACK_TOKEN")
-	os.Unsetenv("TEST_DISCORD_TOKEN")
-	os.Unsetenv("TEST_DISCORD_SERVER_ID")
 }
 
 func Test_setSlackListenerPort(t *testing.T) {
-	os.Setenv("TEST_SLACK_TOKEN", "TESTTOKEN")
-	os.Setenv("TEST_SLACK_INTERACTIONS_CALLBACK_PATH", "TESTPATH")
+	t.Setenv("TEST_SLACK_TOKEN", "TESTTOKEN")
+	t.Setenv("TEST_SLACK_INTERACTIONS_CALLBACK_PATH", "TESTPATH")
 
 	baseBot := func() *models.Bot {
 		bot := new(models.Bot)
@@ -185,7 +156,7 @@ func Test_setSlackListenerPort(t *testing.T) {
 	t.Run("slack listener port reads from env var config", func(t *testing.T) {
 		bot := baseBot()
 		bot.SlackListenerPort = "${TEST_SLACK_LISTENER_PORT}"
-		os.Setenv("TEST_SLACK_LISTENER_PORT", "TESTPORT")
+		t.Setenv("TEST_SLACK_LISTENER_PORT", "TESTPORT")
 		validateRemoteSetup(bot)
 		configureChatApplication(bot)
 
@@ -209,7 +180,6 @@ func Test_setSlackListenerPort(t *testing.T) {
 	})
 
 	t.Run("slack listener port defaults if expected env var is empty", func(t *testing.T) {
-		os.Unsetenv("TEST_SLACK_LISTENER_PORT")
 		bot := baseBot()
 		bot.SlackListenerPort = "${TEST_SLACK_LISTENER_PORT}"
 		validateRemoteSetup(bot)
@@ -299,8 +269,7 @@ func TestConfigure(t *testing.T) {
 	testBot.Name = "mybot(${FB_ENV})"
 	testBot.CLI = true
 
-	os.Setenv("FB_ENV", "dev")
-	defer os.Unsetenv("FB_ENV")
+	t.Setenv("FB_ENV", "dev")
 
 	type args struct {
 		bot *models.Bot

--- a/core/matcher.go
+++ b/core/matcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/mohae/deepcopy"
+	"github.com/rs/zerolog/log"
 
 	"github.com/target/flottbot/handlers"
 	"github.com/target/flottbot/models"
@@ -76,21 +77,21 @@ func handleChatServiceRule(outputMsgs chan<- models.Message, message models.Mess
 	if rule.Respond != "" || rule.Hear != "" {
 		// You can only use 'respond' OR 'hear'
 		if rule.Respond != "" && rule.Hear != "" {
-			bot.Log.Debug().Msgf("rule '%s' has both 'hear' and 'match' or 'respond' defined. please choose one or the other", rule.Name)
+			log.Debug().Msgf("rule %#q has both 'hear' and 'match' or 'respond' defined. please choose one or the other", rule.Name)
 		}
 		// Args are not implemented for 'hear'
 		if rule.Hear != "" && len(rule.Args) > 0 {
-			bot.Log.Debug().Msgf("rule '%s' has both 'args' and 'hear' set. to use 'args', use 'respond' instead of 'hear'", rule.Name)
+			log.Debug().Msgf("rule %#q has both 'args' and 'hear' set. to use 'args', use 'respond' instead of 'hear'", rule.Name)
 		}
 
 		if hit && message.ThreadTimestamp != "" && rule.IgnoreThreads {
-			bot.Log.Debug().Msg("response suppressed due to 'ignore_threads' being set")
+			log.Debug().Msg("response suppressed due to 'ignore_threads' being set")
 			return true, true
 		}
 
 		// check if limit_to_rooms is set on the rule
 		if hit && len(rule.LimitToRooms) > 0 {
-			bot.Log.Debug().Msgf("rule '%s' has 'limit_to_rooms' set - checking whether message should be processed further", rule.Name)
+			log.Debug().Msgf("rule %#q has 'limit_to_rooms' set - checking whether message should be processed further", rule.Name)
 			// do we have a channel name to work with?
 			if message.ChannelName != "" {
 				// keep track of whether room is in list
@@ -109,12 +110,12 @@ func handleChatServiceRule(outputMsgs chan<- models.Message, message models.Mess
 				// in the list of rooms the rule is limited to
 				// suppress the response
 				if !isInLimitToRooms {
-					bot.Log.Debug().Msgf("rule '%s' was matched but skipped due to message not coming from a room defined in 'limit_to_rooms'", rule.Name)
+					log.Debug().Msgf("rule %#q was matched but skipped due to message not coming from a room defined in 'limit_to_rooms'", rule.Name)
 					return true, false
 				}
 			}
 
-			bot.Log.Debug().Msgf("rule '%s' has 'limit_to_rooms' set, but the message didn't include the channel name to compare against", rule.Name)
+			log.Debug().Msgf("rule %#q has 'limit_to_rooms' set, but the message didn't include the channel name to compare against", rule.Name)
 		}
 
 		// if it's a 'respond' rule, make sure the bot was mentioned
@@ -123,7 +124,7 @@ func handleChatServiceRule(outputMsgs chan<- models.Message, message models.Mess
 		}
 
 		if hit {
-			bot.Log.Info().Msgf("found rule match '%s' for input '%s'", rule.Name, message.Input)
+			log.Info().Msgf("found rule match %#q for input %#q", rule.Name, message.Input)
 			// Don't go through more rules if rule is matched
 			match, stopSearch = true, true
 			// Publish metric to prometheus - metricname will be combination of bot name and rule name
@@ -166,7 +167,7 @@ func handleNoMatch(outputMsgs chan<- models.Message, message models.Message, hit
 	if message.Type == models.MsgTypeDirect || message.BotMentioned {
 		// Do not send help message if DisableNoMatchHelp is true
 		if !bot.DisableNoMatchHelp {
-			bot.Log.Info().Msg("bot was addressed, but no rule matched - showing help")
+			log.Info().Msg("bot was addressed, but no rule matched - showing help")
 			// Publish metric as none
 			Prommetric(bot.Name+"-None", bot)
 			// Set custom_help_text if it is set in bot.yml
@@ -195,7 +196,7 @@ func isValidHitChatRule(message *models.Message, rule models.Rule, processedInpu
 	// Check to honor allow_users or allow_usergroups
 	canRunRule := utils.CanTrigger(message.Vars["_user.name"], message.Vars["_user.id"], rule, bot)
 	if !canRunRule {
-		message.Output = fmt.Sprintf("You are not allowed to run the '%s' rule.", rule.Name)
+		message.Output = fmt.Sprintf("You are not allowed to run the %#q rule.", rule.Name)
 		// forcing direct message
 		// message.DirectMessageOnly = true
 		message.Type = models.MsgTypeDirect
@@ -277,15 +278,15 @@ func doRuleActions(message models.Message, outputMsgs chan<- models.Message, rul
 		switch strings.ToLower(action.Type) {
 		// HTTP actions.
 		case "get", "post", "put":
-			bot.Log.Debug().Msgf("executing action '%s'...", action.Name)
-			err = handleHTTP(action, &message, bot)
+			log.Debug().Msgf("executing action %#q...", action.Name)
+			err = handleHTTP(action, &message)
 		// Exec (script) actions
 		case "exec":
-			bot.Log.Debug().Msgf("executing action '%s'...", action.Name)
-			err = handleExec(action, &message, bot)
+			log.Debug().Msgf("executing action %#q...", action.Name)
+			err = handleExec(action, &message)
 		// Normal message/log actions
 		case "message", "log":
-			bot.Log.Debug().Msgf("executing action '%s'...", action.Name)
+			log.Debug().Msgf("executing action %#q...", action.Name)
 			// Log actions cannot direct message users by default
 			directive := rule.DirectMessageOnly
 			if action.Type == "log" {
@@ -296,7 +297,7 @@ func doRuleActions(message models.Message, outputMsgs chan<- models.Message, rul
 			err = handleMessage(action, outputMsgs, &copy, directive, rule.StartMessageThread, hitRule, bot)
 		// Fallback to error if action type is invalid
 		default:
-			bot.Log.Error().Msgf("the rule '%s' of type '%s' is not a supported action", action.Name, action.Type)
+			log.Error().Msgf("the rule %#q of type %#q is not a supported action", action.Name, action.Type)
 		}
 
 		// Handle reaction update
@@ -304,7 +305,7 @@ func doRuleActions(message models.Message, outputMsgs chan<- models.Message, rul
 
 		// Handle error
 		if err != nil {
-			bot.Log.Error().Msg(err.Error())
+			log.Error().Msg(err.Error())
 		}
 	}
 
@@ -321,9 +322,9 @@ func doRuleActions(message models.Message, outputMsgs chan<- models.Message, rul
 	}
 
 	// After running through all the actions, compose final message
-	val, err := craftResponse(rule, message, bot)
+	val, err := craftResponse(rule, message)
 	if err != nil {
-		bot.Log.Error().Msg(err.Error())
+		log.Error().Msg(err.Error())
 		message.Output = err.Error()
 		outputMsgs <- message
 	} else {
@@ -341,7 +342,7 @@ func doRuleActions(message models.Message, outputMsgs chan<- models.Message, rul
 }
 
 // craftResponse handles format_output to make the final message from the bot user-friendly
-func craftResponse(rule models.Rule, msg models.Message, bot *models.Bot) (string, error) {
+func craftResponse(rule models.Rule, msg models.Message) (string, error) {
 	// The user removed the 'format_output' field, or it's not set
 	if rule.FormatOutput == "" {
 		return "", errors.New("hmm, the 'format_output' field in your configuration is empty")
@@ -350,16 +351,18 @@ func craftResponse(rule models.Rule, msg models.Message, bot *models.Bot) (strin
 	// None of the rooms specified in 'output_to_rooms' exist
 	if !rule.DirectMessageOnly && len(rule.OutputToRooms) > 0 && len(msg.OutputToRooms) == 0 {
 		msg := fmt.Sprintf("Could not find any of the rooms specified in 'output_to_rooms' while 'direct_message_only' is set to false. "+
-			"Please check rule '%s'", rule.Name)
+			"Please check rule %#q", rule.Name)
+
 		if len(rule.OutputToUsers) == 0 {
 			return "", errors.New(msg)
 		}
-		bot.Log.Warn().Msg(msg)
+
+		log.Warn().Msg(msg)
 	}
 
 	// Simple warning that we will ignore 'output_to_rooms' when 'direct_message_only' is set
 	if rule.DirectMessageOnly && len(rule.OutputToRooms) > 0 {
-		bot.Log.Debug().Msgf("the rule '%s' has 'direct_message_only' set, 'output_to_rooms' will be ignored", rule.Name)
+		log.Debug().Msgf("the rule %#q has 'direct_message_only' set, 'output_to_rooms' will be ignored", rule.Name)
 	}
 
 	// Use FormatOutput as source for output and find variables and replace content the variable exists
@@ -387,12 +390,12 @@ func craftResponse(rule models.Rule, msg models.Message, bot *models.Bot) (strin
 }
 
 // Handle script execution actions
-func handleExec(action models.Action, msg *models.Message, bot *models.Bot) error {
+func handleExec(action models.Action, msg *models.Message) error {
 	if action.Cmd == "" {
-		return fmt.Errorf("no command was supplied for the '%s' action named: %s", action.Type, action.Name)
+		return fmt.Errorf("no command was supplied for the %#q action named: %s", action.Type, action.Name)
 	}
 
-	resp, err := handlers.ScriptExec(action, msg, bot)
+	resp, err := handlers.ScriptExec(action, msg)
 
 	// Set explicit variables to make script output, script status code accessible in rules
 	msg.Vars["_exec_output"] = resp.Output
@@ -406,24 +409,24 @@ func handleExec(action models.Action, msg *models.Message, bot *models.Bot) erro
 }
 
 // Handle HTTP call actions
-func handleHTTP(action models.Action, msg *models.Message, bot *models.Bot) error {
+func handleHTTP(action models.Action, msg *models.Message) error {
 	if action.URL == "" {
-		return fmt.Errorf("no URL was supplied for the '%s' action named: %s", action.Type, action.Name)
+		return fmt.Errorf("no URL was supplied for the %#q action named: %s", action.Type, action.Name)
 	}
 
-	resp, err := handlers.HTTPReq(action, msg, bot)
+	resp, err := handlers.HTTPReq(action, msg)
 	if err != nil {
-		msg.Error = fmt.Sprintf("error in request made by action '%s' - see bot admin for more information", action.Name)
+		msg.Error = fmt.Sprintf("error in request made by action %#q - see bot admin for more information", action.Name)
 		return err
 	}
 
 	// Just a friendly debugger warning on failed requests
 	if resp.Status >= 400 {
-		bot.Log.Debug().Msgf("error in request made by action '%s' - '%s' returned '%d' with response: %s", action.Name, action.URL, resp.Status, resp.Raw)
+		log.Debug().Msgf("error in request made by action %#q - %#q returned '%d' with response: %s", action.Name, action.URL, resp.Status, resp.Raw)
 	}
 
 	// Always store raw response
-	bot.Log.Debug().Msgf("successfully executed action '%s'", action.Name)
+	log.Debug().Msgf("successfully executed action %#q", action.Name)
 	// Set explicit variables to make raw response output, http status code accessible in rules
 	msg.Vars["_raw_http_output"] = resp.Raw
 	msg.Vars["_raw_http_status"] = strconv.Itoa(resp.Status)
@@ -482,13 +485,13 @@ func handleMessage(action models.Action, outputMsgs chan<- models.Message, msg *
 
 	// bridge for deprecation of LimitToRooms on action
 	if len(action.LimitToRooms) > 0 && len(action.OutputToRooms) == 0 {
-		bot.Log.Warn().Msgf("'limit_to_rooms' on actions is deprecated and will be removed in the next version - update action '%s' to use `output_to_rooms' instead", action.Name)
+		log.Warn().Msgf("'limit_to_rooms' on actions is deprecated and will be removed in the next version - update action %#q to use `output_to_rooms' instead", action.Name)
 		action.OutputToRooms = action.LimitToRooms[:]
 	}
 
 	// Send to desired room(s)
 	if direct && len(action.OutputToRooms) > 0 { // direct=true and limit_to_rooms is specified
-		bot.Log.Debug().Msgf("'direct_message_only' is set - 'limit_to_rooms' field on the '%s' action will be ignored", action.Name)
+		log.Debug().Msgf("'direct_message_only' is set - 'limit_to_rooms' field on the %#q action will be ignored", action.Name)
 	} else if !direct && len(action.OutputToRooms) > 0 { // direct=false and limit_to_rooms is specified
 		msg.OutputToRooms = utils.GetRoomIDs(action.OutputToRooms, bot)
 
@@ -521,7 +524,7 @@ func updateReaction(action models.Action, rule *models.Rule, vars map[string]str
 		if strings.Contains(action.Reaction, "{{") {
 			reaction, err := utils.Substitute(action.Reaction, vars)
 			if err != nil {
-				bot.Log.Error().Msg(err.Error())
+				log.Error().Msg(err.Error())
 				return
 			}
 			action.Reaction = reaction
@@ -531,7 +534,7 @@ func updateReaction(action models.Action, rule *models.Rule, vars map[string]str
 
 			t, err = template.New("update_reaction").Funcs(sprig.FuncMap()).Parse(action.Reaction)
 			if err != nil {
-				bot.Log.Error().Msgf("failed to update reaction '%s'", rule.Reaction)
+				log.Error().Msgf("failed to update reaction %#q", rule.Reaction)
 				return
 			}
 			buf := new(bytes.Buffer)

--- a/core/outputs.go
+++ b/core/outputs.go
@@ -3,6 +3,7 @@ package core
 import (
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/remote/cli"
 	"github.com/target/flottbot/remote/discord"
@@ -17,13 +18,15 @@ func Outputs(outputMsgs <-chan models.Message, hitRule <-chan models.Rule, bot *
 		message := <-outputMsgs
 		rule := <-hitRule
 		service := message.Service
+
 		switch service {
 		case models.MsgServiceChat, models.MsgServiceScheduler:
 			chatApp := strings.ToLower(bot.ChatApplication)
+
 			switch chatApp {
 			case "discord":
 				if service == models.MsgServiceScheduler {
-					bot.Log.Warn().Msg("scheduler does not currently support discord")
+					log.Warn().Msg("scheduler does not currently support discord")
 					break
 				}
 				remoteDiscord := &discord.Client{Token: bot.DiscordToken}
@@ -50,15 +53,15 @@ func Outputs(outputMsgs <-chan models.Message, hitRule <-chan models.Rule, bot *
 				}
 				remoteTelegram.Send(message, bot)
 			default:
-				bot.Log.Error().Msgf("chat application '%s' is not supported", chatApp)
+				log.Error().Msgf("chat application %#q is not supported", chatApp)
 			}
 		case models.MsgServiceCLI:
 			remoteCLI := &cli.Client{}
 			remoteCLI.Send(message, bot)
 		case models.MsgServiceUnknown:
-			bot.Log.Error().Msg("found unknown service")
+			log.Error().Msg("found unknown service")
 		default:
-			bot.Log.Error().Msg("no service found")
+			log.Error().Msg("no service found")
 		}
 	}
 }

--- a/core/prommetric.go
+++ b/core/prommetric.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 )
 
@@ -31,11 +32,11 @@ func Prommetric(input string, bot *models.Bot) {
 			// metrics health check handler
 			promHealthHandle := func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
-					bot.Log.Error().Msgf("prometheus server: invalid method '%s'", r.Method)
+					log.Error().Msgf("prometheus server: invalid method %#q", r.Method)
 					w.WriteHeader(http.StatusMethodNotAllowed)
 					return
 				}
-				bot.Log.Debug().Msg("prometheus server: health check hit!")
+				log.Debug().Msg("prometheus server: health check hit!")
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("OK"))
 			}
@@ -47,7 +48,7 @@ func Prommetric(input string, bot *models.Bot) {
 
 			// start prometheus server
 			go http.ListenAndServe(":8080", promRouter)
-			bot.Log.Info().Msg("prometheus server: serving metrics at /metrics")
+			log.Info().Msg("prometheus server: serving metrics at /metrics")
 		} else {
 			botResponseCollector.With(prometheus.Labels{"rulename": input}).Inc()
 		}

--- a/core/remotes.go
+++ b/core/remotes.go
@@ -3,6 +3,7 @@ package core
 import (
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/remote/cli"
 	"github.com/target/flottbot/remote/discord"
@@ -28,9 +29,9 @@ import (
 // TODO: Refactor to keep remote specific stuff in remote/
 func Remotes(inputMsgs chan<- models.Message, rules map[string]models.Rule, bot *models.Bot) {
 	// Run a chat application
-	if bot.RunChat {
+	if bot.ChatApplication != "" {
 		chatApp := strings.ToLower(bot.ChatApplication)
-		bot.Log.Info().Msgf("running '%s' on '%s'", bot.Name, strings.Title(chatApp))
+		log.Info().Msgf("running %#q on %#q", bot.Name, strings.Title(chatApp))
 		switch chatApp {
 		// Setup remote to use the Discord client to read from Discord
 		case "discord":
@@ -59,21 +60,21 @@ func Remotes(inputMsgs chan<- models.Message, rules map[string]models.Rule, bot 
 			// Read messages from Telegram
 			go remoteTelegram.Read(inputMsgs, rules, bot)
 		default:
-			bot.Log.Error().Msgf("chat application '%s' is not supported", chatApp)
+			log.Error().Msgf("chat application %#q is not supported", chatApp)
 		}
 	}
 
 	// Run CLI mode
-	if bot.RunCLI {
-		bot.Log.Info().Msgf("running cli mode for '%s'", bot.Name)
+	if bot.CLI {
+		log.Info().Msgf("running cli mode for %#q", bot.Name)
 		remoteCLI := &cli.Client{}
 		go remoteCLI.Read(inputMsgs, rules, bot)
 	}
 
 	// Run Scheduler
 	// CAUTION: Will not work properly when multiple instances of your bot are deployed (i.e. will get duplicated scheduled output)
-	if bot.RunScheduler {
-		bot.Log.Info().Msgf("running scheduler for '%s'", bot.Name)
+	if bot.Scheduler {
+		log.Info().Msgf("running scheduler for %#q", bot.Name)
 		remoteScheduler := &scheduler.Client{}
 		go remoteScheduler.Read(inputMsgs, rules, bot)
 	}

--- a/core/rules.go
+++ b/core/rules.go
@@ -19,14 +19,14 @@ import (
 // The rules map is used to dictate the bots behavior and response patterns.
 func Rules(rules *map[string]models.Rule, bot *models.Bot) {
 	// Check if the rules directory even exists
-	bot.Log.Debug().Msg("looking for rules directory...")
+	log.Debug().Msg("looking for rules directory...")
 	searchDir, err := utils.PathExists(path.Join("config", "rules"))
 	if err != nil {
-		bot.Log.Error().Msgf("could not parse rules: %v", err)
+		log.Error().Msgf("could not parse rules: %v", err)
 	}
 
 	// Loop through the rules directory and create a list of rules
-	bot.Log.Info().Msg("fetching all rule files...")
+	log.Info().Msg("fetching all rule files...")
 	fileList := []string{}
 	err = filepath.Walk(searchDir, func(path string, f os.FileInfo, err error) error {
 		if !f.IsDir() {
@@ -35,24 +35,24 @@ func Rules(rules *map[string]models.Rule, bot *models.Bot) {
 		return nil
 	})
 	if err != nil {
-		bot.Log.Error().Msgf("could not parse rules: %v", err)
+		log.Error().Msgf("could not parse rules: %v", err)
 	}
 
 	// If the rules directory is empty, log a warning and exit the function
 	if len(fileList) == 0 {
-		bot.Log.Warn().Msg("looks like there aren't any rules")
+		log.Warn().Msg("looks like there aren't any rules")
 		return
 	}
 
 	// Loop through the list of rules, creating a Rule object
 	// for each rule, then populate the map of Rule objects
-	bot.Log.Debug().Msg("reading and parsing rule files...")
+	log.Debug().Msgf("parsing %d rule files...", len(fileList))
 	for _, ruleFile := range fileList {
 		ruleConf := viper.New()
 		ruleConf.SetConfigFile(ruleFile)
 		err := ruleConf.ReadInConfig()
 		if err != nil {
-			bot.Log.Error().Msgf("error while reading rule file '%s': %v", ruleFile, err)
+			log.Error().Msgf("error while reading rule file %#q: %v", ruleFile, err)
 		}
 
 		rule := models.Rule{}
@@ -67,7 +67,7 @@ func Rules(rules *map[string]models.Rule, bot *models.Bot) {
 		(*rules)[ruleFile] = rule
 	}
 
-	bot.Log.Info().Msgf("configured '%s' rules!", bot.Name)
+	log.Info().Msgf("configured %#q rules!", bot.Name)
 }
 
 // Validate applies any environmental changes

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -49,10 +49,7 @@ func TestHTTPReq(t *testing.T) {
 	type args struct {
 		args models.Action
 		msg  *models.Message
-		bot  *models.Bot
 	}
-
-	bot := new(models.Bot)
 
 	tsOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -119,16 +116,16 @@ func TestHTTPReq(t *testing.T) {
 		want    *models.HTTPResponse
 		wantErr bool
 	}{
-		{"HTTPReq GET", args{args: TestGETAction, msg: &TestMessage, bot: bot}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
-		{"HTTPReq POST", args{args: TestPOSTAction, msg: &TestMessage, bot: bot}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
-		{"HTTPReq No Query", args{args: TestEmptyQueryAction, msg: &TestMessage, bot: bot}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
-		{"HTTPReq Error Response", args{args: TestErrorResponseAction, msg: &TestMessage, bot: bot}, &models.HTTPResponse{Status: 502, Raw: "", Data: ""}, false},
-		{"HTTPReq with Sub", args{args: TestQueryWithSubsAction, msg: &TestMessage, bot: bot}, nil, true},
-		{"HTTPReq with Error", args{args: TestWithError, msg: &TestMessage, bot: bot}, nil, true},
+		{"HTTPReq GET", args{args: TestGETAction, msg: &TestMessage}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
+		{"HTTPReq POST", args{args: TestPOSTAction, msg: &TestMessage}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
+		{"HTTPReq No Query", args{args: TestEmptyQueryAction, msg: &TestMessage}, &models.HTTPResponse{Status: 200, Raw: "", Data: ""}, false},
+		{"HTTPReq Error Response", args{args: TestErrorResponseAction, msg: &TestMessage}, &models.HTTPResponse{Status: 502, Raw: "", Data: ""}, false},
+		{"HTTPReq with Sub", args{args: TestQueryWithSubsAction, msg: &TestMessage}, nil, true},
+		{"HTTPReq with Error", args{args: TestWithError, msg: &TestMessage}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := HTTPReq(tt.args.args, tt.args.msg, tt.args.bot)
+			got, err := HTTPReq(tt.args.args, tt.args.msg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HTTPReq() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/handlers/script.go
+++ b/handlers/script.go
@@ -9,13 +9,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/utils"
 )
 
 // ScriptExec handles 'exec' actions; script executions for rules
-func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*models.ScriptResponse, error) {
-	bot.Log.Info().Msgf("executing process for action '%s'", args.Name)
+func ScriptExec(args models.Action, msg *models.Message) (*models.ScriptResponse, error) {
+	log.Info().Msgf("executing process for action %#q", args.Name)
 	// Default timeout of 20 seconds for any script execution, modifyable in rule file
 	if args.Timeout == 0 {
 		args.Timeout = 20
@@ -31,9 +32,9 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 	defer cancel()
 
 	// Deal with variable substitution in command
-	bot.Log.Debug().Msgf("command is: [%s]", args.Cmd)
+	log.Debug().Msgf("command is: [%s]", args.Cmd)
 	cmdProcessed, err := utils.Substitute(args.Cmd, msg.Vars)
-	bot.Log.Debug().Msgf("substituted: [%s]", cmdProcessed)
+	log.Debug().Msgf("substituted: [%s]", cmdProcessed)
 	if err != nil {
 		return result, err
 	}
@@ -49,7 +50,7 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 	// Handle timeouts
 	if ctx.Err() == context.DeadlineExceeded {
 		result.Output = "Hmm, something timed out. Please try again."
-		return result, fmt.Errorf("timeout reached, exec process for action '%s' cancelled", args.Name)
+		return result, fmt.Errorf("timeout reached, exec process for action %#q cancelled", args.Name)
 	}
 
 	// Deal with non-zero exit codes
@@ -58,16 +59,16 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 		case *exec.ExitError:
 			ws := err.(*exec.ExitError).Sys().(syscall.WaitStatus)
 			stderr := strings.Trim(string(err.(*exec.ExitError).Stderr), " \n")
-			bot.Log.Debug().Msgf("process for action '%s' exited with status '%d': %s", args.Name, ws.ExitStatus(), stderr)
+			log.Debug().Msgf("process for action %#q exited with status '%d': %s", args.Name, ws.ExitStatus(), stderr)
 			result.Status = ws.ExitStatus()
 			result.Output = stderr
 		case *os.PathError:
-			bot.Log.Debug().Msgf("process for action '%s' exited with status '%d': %v", args.Name, result.Status, err)
+			log.Debug().Msgf("process for action %#q exited with status '%d': %v", args.Name, result.Status, err)
 			result.Status = 127
 			result.Output = err.Error()
 		default:
 			// this should rarely/never get hit
-			bot.Log.Debug().Msgf("couldn't get exit status for action '%s'", args.Name)
+			log.Debug().Msgf("couldn't get exit status for action %#q", args.Name)
 			result.Output = strings.Trim(err.Error(), " \n")
 		}
 		// if something was printed to stdout before the error, use that as output
@@ -79,7 +80,7 @@ func ScriptExec(args models.Action, msg *models.Message, bot *models.Bot) (*mode
 	}
 
 	// should be exit code 0 here
-	bot.Log.Info().Msgf("process finished for action '%s'", args.Name)
+	log.Info().Msgf("process finished for action %#q", args.Name)
 	ws := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	result.Status = ws.ExitStatus()
 	result.Output = strings.Trim(string(out), " \n")

--- a/handlers/script_test.go
+++ b/handlers/script_test.go
@@ -20,10 +20,7 @@ func TestScriptExec(t *testing.T) {
 	type args struct {
 		args models.Action
 		msg  *models.Message
-		bot  *models.Bot
 	}
-
-	bot := new(models.Bot)
 
 	simpleScriptMessage := models.NewMessage()
 	simpleScriptMessage.Vars["test"] = "echo"
@@ -46,17 +43,17 @@ func TestScriptExec(t *testing.T) {
 		want    *models.ScriptResponse
 		wantErr bool
 	}{
-		{"Simple Script", args{args: simpleScriptAction, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 0, Output: "hi there"}, false},
-		{"Slow Script", args{args: slowScriptAction, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 1, Output: "Hmm, something timed out. Please try again."}, true},
-		{"Error Script", args{args: errorScriptAction, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 1, Output: ""}, true},
-		{"Existing Var Script", args{args: varExistsScriptAction, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 0, Output: "echo"}, false},
-		{"Missing Var Script", args{args: varMissingScriptAction, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 1, Output: ""}, true},
-		{"StdOut before exit code 1", args{args: msgBeforeExit, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 1, Output: "error is coming"}, true},
+		{"Simple Script", args{args: simpleScriptAction, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 0, Output: "hi there"}, false},
+		{"Slow Script", args{args: slowScriptAction, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 1, Output: "Hmm, something timed out. Please try again."}, true},
+		{"Error Script", args{args: errorScriptAction, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 1, Output: ""}, true},
+		{"Existing Var Script", args{args: varExistsScriptAction, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 0, Output: "echo"}, false},
+		{"Missing Var Script", args{args: varMissingScriptAction, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 1, Output: ""}, true},
+		{"StdOut before exit code 1", args{args: msgBeforeExit, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 1, Output: "error is coming"}, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ScriptExec(tt.args.args, tt.args.msg, tt.args.bot)
+			got, err := ScriptExec(tt.args.args, tt.args.msg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScriptExec() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -72,10 +69,8 @@ func TestScriptExecWithRegex(t *testing.T) {
 	type args struct {
 		args models.Action
 		msg  *models.Message
-		bot  *models.Bot
 	}
 
-	bot := new(models.Bot)
 	simpleScriptMessage := models.NewMessage()
 
 	cmdNotFound := newExecAction(`/bin/sh ./this/is/a/trap.sh`)
@@ -87,12 +82,12 @@ func TestScriptExecWithRegex(t *testing.T) {
 		wantErr    bool
 		wantRegexp *regexp.Regexp
 	}{
-		{"Script does not exist", args{args: cmdNotFound, msg: &simpleScriptMessage, bot: bot}, &models.ScriptResponse{Status: 2}, true, regexp.MustCompile(`No such file`)},
+		{"Script does not exist", args{args: cmdNotFound, msg: &simpleScriptMessage}, &models.ScriptResponse{Status: 2}, true, regexp.MustCompile(`No such file`)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ScriptExec(tt.args.args, tt.args.msg, tt.args.bot)
+			got, err := ScriptExec(tt.args.args, tt.args.msg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ScriptExec() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/remote/cli/remote.go
+++ b/remote/cli/remote.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/remote"
 	"github.com/target/flottbot/version"
@@ -60,7 +61,7 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		bot.Log.Error().Msgf("Error reading standard input: %v", err)
+		log.Error().Msgf("Error reading standard input: %v", err)
 	}
 }
 

--- a/remote/discord/helper.go
+++ b/remote/discord/helper.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"github.com/bwmarrin/discordgo"
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 )
 
@@ -26,7 +27,7 @@ func populateMessage(message models.Message, msgType models.MessageType, channel
 	if msgType != models.MsgTypeDirect {
 		name, ok := findKey(bot.Rooms, channel)
 		if !ok {
-			bot.Log.Error().Msgf("could not find name of channel '%s'", channel)
+			log.Error().Msgf("could not find name of channel %#q", channel)
 		}
 
 		message.ChannelName = name
@@ -55,12 +56,12 @@ func send(dg *discordgo.Session, message models.Message, bot *models.Bot) {
 	if message.DirectMessageOnly {
 		err := handleDirectMessage(dg, message, bot)
 		if err != nil {
-			bot.Log.Error().Msgf("problem sending message: %v", err)
+			log.Error().Msgf("problem sending message: %v", err)
 		}
 	} else {
 		err := handleNonDirectMessage(dg, message, bot)
 		if err != nil {
-			bot.Log.Error().Msgf("problem sending message: %v", err)
+			log.Error().Msgf("problem sending message: %v", err)
 		}
 	}
 }
@@ -69,13 +70,13 @@ func send(dg *discordgo.Session, message models.Message, bot *models.Bot) {
 func handleDirectMessage(dg *discordgo.Session, message models.Message, bot *models.Bot) error {
 	// Is output to rooms set?
 	if len(message.OutputToRooms) > 0 {
-		bot.Log.Warn().Msg("you have specified 'direct_message_only' as 'true' and provided 'output_to_rooms' -" +
+		log.Warn().Msg("you have specified 'direct_message_only' as 'true' and provided 'output_to_rooms' -" +
 			" messages will not be sent to listed rooms - if you want to send messages to these rooms," +
 			" please set 'direct_message_only' to 'false'")
 	}
 	// Is output to users set?
 	if len(message.OutputToUsers) > 0 {
-		bot.Log.Warn().Msg("you have specified 'direct_message_only' as 'true' and provided 'output_to_users' -" +
+		log.Warn().Msg("you have specified 'direct_message_only' as 'true' and provided 'output_to_users' -" +
 			" messages will not be sent to the listed users (other than you) - if you want to send messages to other users," +
 			" please set 'direct_message_only' to 'false'.")
 	}

--- a/remote/scheduler/remote.go
+++ b/remote/scheduler/remote.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/remote"
 )
@@ -30,7 +31,7 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 	for {
 		_nil := bot.Rooms[""]
 		if len(bot.Rooms) > 0 {
-			bot.Log.Info().Msgf("scheduler connected to '%s' channels: %s", strings.Title(bot.ChatApplication), _nil)
+			log.Info().Msgf("scheduler connected to %#q channels: %s", strings.Title(bot.ChatApplication), _nil)
 			break
 		}
 	}
@@ -44,17 +45,17 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 		if rule.Active && rule.Schedule != "" {
 			// Pre-checks before executing rule as a cron job
 			if len(rule.OutputToRooms) == 0 && len(rule.OutputToUsers) == 0 {
-				bot.Log.Error().Msg("scheduling rules require the 'output_to_rooms' and/or 'output_to_users' fields to be set")
+				log.Error().Msg("scheduling rules require the 'output_to_rooms' and/or 'output_to_users' fields to be set")
 				continue
 			} else if len(rule.OutputToRooms) > 0 && len(bot.Rooms) == 0 {
-				bot.Log.Error().Msgf("unable to connect scheduler to these rooms: %s", rule.OutputToRooms)
+				log.Error().Msgf("unable to connect scheduler to these rooms: %s", rule.OutputToRooms)
 				continue
 			} else if rule.Respond != "" || rule.Hear != "" {
-				bot.Log.Error().Msg("scheduling rules does not allow the 'respond' and 'hear' fields")
+				log.Error().Msg("scheduling rules does not allow the 'respond' and 'hear' fields")
 				continue
 			}
 
-			bot.Log.Info().Msgf("scheduler is adding rule '%s'", rule.Name)
+			log.Info().Msgf("scheduler is adding rule %#q", rule.Name)
 
 			scheduleName := rule.Name
 			input := fmt.Sprintf("<@%s> ", bot.ID) // send message as self
@@ -63,7 +64,7 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 
 			// prepare the job function
 			jobFunc := func() {
-				bot.Log.Info().Msgf("executing scheduler for rule '%s'", scheduleName)
+				log.Info().Msgf("executing scheduler for rule %#q", scheduleName)
 				// build the message
 				message := models.NewMessage()
 				message.Service = models.MsgServiceScheduler
@@ -76,7 +77,7 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 			}
 
 			// use our logger for cron
-			cronLogger := cron.PrintfLogger(&bot.Log)
+			cronLogger := cron.PrintfLogger(&log.Logger)
 
 			// check if the provided schedule is of standard format, ie. 5 fields
 			_, err := cron.ParseStandard(rule.Schedule)
@@ -92,11 +93,11 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 			_, err = job.AddFunc(rule.Schedule, jobFunc)
 			if err != nil {
 				// typically the error is due to incorrect cron format
-				bot.Log.Error().
-					Msgf("unable to add schedule for rule '%s': verify that the supplied schedule is supported", rule.Name)
+				log.Error().
+					Msgf("unable to add schedule for rule %#q: verify that the supplied schedule is supported", rule.Name)
 				// more verbose log. note: will probably convey that spec
 				// needs to be 6 fields, although any supported format will work.
-				bot.Log.Debug().Msgf("error while adding job: %v", err)
+				log.Debug().Msgf("error while adding job: %v", err)
 				continue
 			}
 
@@ -105,11 +106,11 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 	}
 
 	if len(jobs) == 0 {
-		bot.Log.Warn().Msg("no schedules were added - please check for errors")
+		log.Warn().Msg("no schedules were added - please check for errors")
 		return
 	}
 
-	processJobs(jobs, bot)
+	processJobs(jobs)
 }
 
 // Send implementation to satisfy remote interface
@@ -123,7 +124,7 @@ func (c *Client) InteractiveComponents(inputMsgs chan<- models.Message, message 
 }
 
 // Process the Cron jobs
-func processJobs(jobs []*cron.Cron, bot *models.Bot) {
+func processJobs(jobs []*cron.Cron) {
 	// Create wait group for cron jobs and execute them
 	wg := &sync.WaitGroup{}
 	wg.Add(len(jobs))
@@ -134,5 +135,5 @@ func processJobs(jobs []*cron.Cron, bot *models.Bot) {
 		defer job.Stop()
 	}
 	wg.Wait()
-	bot.Log.Warn().Msg("scheduler is closing")
+	log.Warn().Msg("scheduler is closing")
 }

--- a/remote/telegram/remote.go
+++ b/remote/telegram/remote.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 	"github.com/target/flottbot/remote"
 )
@@ -46,7 +47,7 @@ func (c *Client) Read(inputMsgs chan<- models.Message, rules map[string]models.R
 
 	botuser, err := telegramAPI.GetMe()
 	if err != nil {
-		bot.Log.Error().Msg("failed to initialize telegram client")
+		log.Error().Msg("failed to initialize telegram client")
 		return
 	}
 	bot.Name = botuser.UserName
@@ -123,7 +124,7 @@ func (c *Client) Send(message models.Message, bot *models.Bot) {
 	telegramAPI := c.new()
 	chatID, err := strconv.ParseInt(message.ChannelID, 10, 64)
 	if err != nil {
-		bot.Log.Error().Msgf("unable to retrieve chat id '%s'", message.ChannelID)
+		log.Error().Msgf("unable to retrieve chat id %#q", message.ChannelID)
 		return
 	}
 
@@ -132,7 +133,7 @@ func (c *Client) Send(message models.Message, bot *models.Bot) {
 	if message.DirectMessageOnly {
 		chatID, err = strconv.ParseInt(message.Vars["_user.id"], 10, 64)
 		if err != nil {
-			bot.Log.Error().Msgf("unable to retrieve user id '%s' for direct message", message.Vars["_user.id"])
+			log.Error().Msgf("unable to retrieve user id %#q for direct message", message.Vars["_user.id"])
 			return
 		}
 	}

--- a/utils/access_check.go
+++ b/utils/access_check.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/bwmarrin/discordgo"
+	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 	"github.com/target/flottbot/models"
 )
@@ -20,7 +21,7 @@ func CanTrigger(currentUserName string, currentUserID string, rule models.Rule, 
 	// are they ignored directly? deny
 	for _, name := range rule.IgnoreUsers {
 		if name == currentUserName {
-			bot.Log.Info().Msgf("'%s' is on the 'ignore_users' list for rule: '%s'", currentUserName, rule.Name)
+			log.Info().Msgf("%#q is on the 'ignore_users' list for rule: %#q", currentUserName, rule.Name)
 			return false
 		}
 	}
@@ -33,8 +34,8 @@ func CanTrigger(currentUserName string, currentUserID string, rule models.Rule, 
 	}
 
 	if isIgnored {
-		bot.Log.Info().
-			Msgf("'%s' is part of a group in ignore_usergroups: '%s'", currentUserName, strings.Join(rule.IgnoreUserGroups, ", "))
+		log.Info().
+			Msgf("%#q is part of a group in ignore_usergroups: %#q", currentUserName, strings.Join(rule.IgnoreUserGroups, ", "))
 		return false
 	}
 
@@ -73,18 +74,18 @@ func CanTrigger(currentUserName string, currentUserID string, rule models.Rule, 
 
 	if !canRunRule {
 		if len(rule.AllowUsers) > 0 {
-			bot.Log.Info().
-				Msgf("'%s' is not part of allow_users: '%s'", currentUserName, strings.Join(rule.AllowUsers, ", "))
+			log.Info().
+				Msgf("%#q is not part of allow_users: %#q", currentUserName, strings.Join(rule.AllowUsers, ", "))
 		}
 
 		if len(rule.AllowUserIds) > 0 {
-			bot.Log.Info().
-				Msgf("'%s' is not part of allow_userids: '%s'", currentUserID, strings.Join(rule.AllowUserIds, ", "))
+			log.Info().
+				Msgf("%#q is not part of allow_userids: %#q", currentUserID, strings.Join(rule.AllowUserIds, ", "))
 		}
 
 		if len(rule.AllowUserGroups) > 0 {
-			bot.Log.Info().
-				Msgf("'%s' is not part of any groups in allow_usergroups: '%s'", currentUserName, strings.Join(rule.AllowUserGroups, ", "))
+			log.Info().
+				Msgf("%#q is not part of any groups in allow_usergroups: %#q", currentUserName, strings.Join(rule.AllowUserGroups, ", "))
 		}
 	}
 
@@ -111,7 +112,7 @@ func isMemberOfGroup(currentUserID string, userGroups []string, bot *models.Bot)
 
 		usr, err = dg.GuildMember(bot.DiscordServerID, currentUserID)
 		if err != nil {
-			bot.Log.Error().Msgf("error while searching for user - error: %v", err)
+			log.Error().Msgf("error while searching for user - error: %v", err)
 			return false, nil
 		}
 
@@ -135,7 +136,7 @@ func isMemberOfGroup(currentUserID string, userGroups []string, bot *models.Bot)
 					// Get the members of the group
 					userGroupMembers, err := api.GetUserGroupMembers(knownUserGroupID)
 					if err != nil {
-						bot.Log.Error().Msgf("unable to retrieve user group members, %v", err)
+						log.Error().Msgf("unable to retrieve user group members, %v", err)
 					}
 					// Check if any of the members are the current user
 					for _, userGroupMemberID := range userGroupMembers {
@@ -151,7 +152,7 @@ func isMemberOfGroup(currentUserID string, userGroups []string, bot *models.Bot)
 
 		return false, nil
 	default:
-		bot.Log.Error().Msgf("chat application '%s' is not supported", capp)
+		log.Error().Msgf("chat application %#q is not supported", capp)
 		return false, nil
 	}
 }

--- a/utils/is_set.go
+++ b/utils/is_set.go
@@ -1,0 +1,15 @@
+package utils
+
+import "strings"
+
+// IsSet is a helper function to check whether any of the supplied
+// strings are empty or unsubstituted (ie. still in ${<string>} format)
+func IsSet(s ...string) bool {
+	for _, v := range s {
+		if v == "" || strings.HasPrefix(v, "${") {
+			return false
+		}
+	}
+
+	return true
+}

--- a/utils/is_set_test.go
+++ b/utils/is_set_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import "testing"
+
+func TestIsSet(t *testing.T) {
+	type args struct {
+		s []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"empty",
+			args{[]string{""}},
+			false,
+		},
+		{
+			"unset/unsubstituted",
+			args{[]string{"${foo}"}},
+			false,
+		},
+		{
+			"set",
+			args{[]string{"bar"}},
+			true,
+		},
+		{
+			"many - one unset",
+			args{[]string{"foo", "bar", "${foo}"}},
+			false,
+		},
+		{
+			"many - all set",
+			args{[]string{"foo", "bar"}},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSet(tt.args.s...); got != tt.want {
+				t.Errorf("IsSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 // Match checks given value against given pattern
@@ -43,9 +44,10 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 			tok := strip(hit)
 			// Check if token was already stored as a token
 			if _, ok := tokens[tok]; ok {
+				// TODO: check on this
 				envTok := os.Getenv(tok)
 				if envTok != "" {
-					log.Printf("Warning: you are using %s as '%s' but it is also an environment variable. Consider renaming.", tok, tok)
+					log.Warn().Msgf("you are using %s as %#q but it is also an environment variable. consider renaming.", tok, tok)
 				}
 				value = strings.Replace(value, hit, orDefault(tokens[tok], ""), -1)
 				continue
@@ -55,7 +57,7 @@ func Substitute(value string, tokens map[string]string) (string, error) {
 			if envTok != "" {
 				value = strings.Replace(value, hit, os.Getenv(tok), -1)
 			} else {
-				err := fmt.Sprintf("Variable '%s' has not been defined.", tok)
+				err := fmt.Sprintf("Variable %#q has not been defined.", tok)
 				errs = append(errs, err)
 			}
 		}

--- a/utils/parse_test.go
+++ b/utils/parse_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
@@ -47,8 +46,7 @@ func TestSubstitute(t *testing.T) {
 		tokens map[string]string
 	}
 
-	os.Setenv("TEST_ENV_VAR", "1234")
-	defer os.Unsetenv("TEST_ENV_VAR")
+	t.Setenv("TEST_ENV_VAR", "1234")
 
 	tests := []struct {
 		name    string

--- a/utils/path.go
+++ b/utils/path.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	errCurrPath      = errors.New("could not get the current directory")
-	errPathNotExists = errors.New("directory named '%s' does not exist at: %s")
+	errPathNotExists = errors.New("directory named %#q does not exist at: %s")
 	errPathOther     = errors.New("there was an error attempting to access the directory")
 )
 

--- a/utils/rooms.go
+++ b/utils/rooms.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"github.com/target/flottbot/models"
 )
 
@@ -15,7 +16,7 @@ func GetRoomIDs(wantRooms []string, bot *models.Bot) []string {
 		if roomMatch != "" {
 			rooms = append(rooms, roomMatch)
 		} else {
-			bot.Log.Error().Msgf("room '%s' does not exist", room)
+			log.Error().Msgf("room %#q does not exist", room)
 		}
 	}
 


### PR DESCRIPTION
### ❤ THANKS FOR HELPING OUT :D

## Proposed change

Set up log globally to avoid passing Bot for just logging. Also includes change that closes https://github.com/target/flottbot/issues/187

Additionally:
- moves Bot constructor into `models/bot.go`
- moves a utility function (`IsSet`) into `utils/`
- injects logger into Slack Socket Mode

## Types of changes

What types of changes is this pull request introducing to flottbot? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

You can fill this out after creating your PR. _Put an `x` in the boxes that apply_

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
