### PR TITLE
ci(binary): fix binary release in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: "1.18"
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix pipeline.. `version` is not for `Go` version 🤦🏼 