### PR TITLE
feat: support regex capture groups as arguments

### DIFF
--- a/core/matcher.go
+++ b/core/matcher.go
@@ -603,7 +603,7 @@ func updateReaction(action models.Action, rule *models.Rule, vars map[string]str
 }
 
 // parseArgumentsFromRegex parses an input string against a regex rule
-// and returns a map of argument names and their value
+// and returns a map of argument names and their value.
 func parseArgumentsFromRegex(re, input string) map[string]string {
 	args := make(map[string]string)
 
@@ -613,17 +613,18 @@ func parseArgumentsFromRegex(re, input string) map[string]string {
 		return args
 	}
 
-	// get all capture group names
+	// get all capture group names.
 	reNames := r.SubexpNames()
 
-	// get all capture group values
+	// get all capture group values.
 	reValues := r.FindStringSubmatch(input)
 
-	// assign capture group key/value to args map
+	// assign capture group key/value to args map.
 	for index, name := range reNames {
 		if index == 0 || name == "" {
 			continue
 		}
+
 		args[name] = reValues[index]
 	}
 

--- a/core/matcher.go
+++ b/core/matcher.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"html"
 	"html/template"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -217,6 +218,15 @@ func isValidHitChatRule(message *models.Message, rule models.Rule, processedInpu
 
 		return false
 	}
+
+	for name, value := range parseArgumentsFromRegex(rule.Hear, message.Input) {
+		message.Vars[name] = value
+	}
+
+	for name, value := range parseArgumentsFromRegex(rule.Respond, message.Input) {
+		message.Vars[name] = value
+	}
+
 	// If this wasn't a 'hear' rule, handle the args
 	if rule.Hear == "" {
 		// Get all the args that the message sender supplied
@@ -590,4 +600,32 @@ func updateReaction(action models.Action, rule *models.Rule, vars map[string]str
 			rule.Reaction = action.Reaction
 		}
 	}
+}
+
+// parseArgumentsFromRegex parses an input string against a regex rule
+// and returns a map of argument names and their value
+func parseArgumentsFromRegex(re, input string) map[string]string {
+	args := make(map[string]string)
+
+	// try compliling the rule as regex, ignoring non-regex rules
+	r, err := regexp.Compile(strings.Trim(re, "/"))
+	if err != nil {
+		return args
+	}
+
+	// get all capture group names
+	reNames := r.SubexpNames()
+
+	// get all capture group values
+	reValues := r.FindStringSubmatch(input)
+
+	// assign capture group key/value to args map
+	for index, name := range reNames {
+		if index == 0 || name == "" {
+			continue
+		}
+		args[name] = reValues[index]
+	}
+
+	return args
 }


### PR DESCRIPTION
## Proposed change

This change adds support for regex capture groups as input arguments (closes #10). It does so by taking advantage of [named & numbered capture groups](https://pkg.go.dev/regexp/syntax#:~:text=named%20%26%20numbered%20capturing%20group) in the standard library.

This can be used in both "respond" and "hear" rules. Doing so adds argument support for "hear" rules, discussed in #204.

In the following example, the capture group named `word` is processed as an argument with the same name.

```yaml
name: hear
active: true
hear: /can you say (?P<word>\S+) for me/
format_output: "I can say ${word} for you"
```

See the unit tests for more detailed examples.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
