### PR TITLE
enhance(ci): group more types of updates and automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,10 +14,15 @@
   },
   "packageRules": [
     {
+      "description": "Automerge non-major updates",
       "matchUpdateTypes": [
-        "patch"
+        "minor",
+        "digest",
+        "patch",
+        "pin"
       ],
-      "groupName": "patch deps"
+      "groupName": "mergeable deps",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
reduce noise by configuring auto-merge on non major dependency updates. can't take effect until repo settings are updated due to reviewer requirement that's in place.