### PR TITLE
Enhance Help Text Customization in Core Configuration

### DIFF
--- a/config-example/bot.yml
+++ b/config-example/bot.yml
@@ -33,6 +33,10 @@ metrics: false
 # false: disable prometheus metrics
 
 # Optional
+# If you just want to customize default text of help, and keep help generation as is
+# custom_help_text_prefix: "Hello from flotbot! I understand these commands:"
+
+# Optional
 # If you want to customize your help text
 # custom_help_text: >
 #   I can help you with this stuff:

--- a/core/matcher.go
+++ b/core/matcher.go
@@ -190,6 +190,10 @@ func handleNoMatch(outputMsgs chan<- models.Message, message models.Message, hit
 			// If custom_help_text is not set, use default Help Text, for each rule use help_text from rule file
 			if helpMsg == "" {
 				helpMsg = "I understand these commands: \n"
+				if bot.CustomHelpTextPrefix != "" {
+					helpMsg = bot.CustomHelpTextPrefix + "\n"
+				}
+
 				// Go through all the rules and collect the help_text
 				for _, rule := range rules {
 					// Is the rule active and does the user want to expose the help for it? 'hear' rules don't show in help by default

--- a/models/bot.go
+++ b/models/bot.go
@@ -39,6 +39,7 @@ type Bot struct {
 	Debug                         bool              `mapstructure:"debug,omitempty"`
 	Metrics                       bool              `mapstructure:"metrics,omitempty"`
 	CustomHelpText                string            `mapstructure:"custom_help_text,omitempty"`
+	CustomHelpTextPrefix          string            `mapstructure:"custom_help_text_prefix,omitempty"`
 	DisableNoMatchHelp            bool              `mapstructure:"disable_no_match_help,omitempty"`
 	RespondToBots                 bool              `mapstructure:"respond_to_bots,omitempty"`
 	// System


### PR DESCRIPTION
## Proposed change

This pull request introduces additional customization for the help text in the bot's core functionality. A new configuration option, `custom_help_text_prefix`, has been added to allow users to set a custom prefix for the default help message without altering the automatic help generation process.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have added necessary documentation (if appropriate)
