### PR TITLE
Add Option to Force Replies in Thread for Google Chat Bot

### DIFF
--- a/models/bot.go
+++ b/models/bot.go
@@ -28,6 +28,7 @@ type Bot struct {
 	GoogleChatProjectID           string            `mapstructure:"google_chat_project_id"`
 	GoogleChatSubscriptionID      string            `mapstructure:"google_chat_subscription_id"`
 	GoogleChatCredentials         string            `mapstructure:"google_chat_credentials"`
+	GoogleChatForceReplyToThread  bool              `mapstructure:"google_chat_force_reply_to_thread"`
 	TelegramToken                 string            `mapstructure:"telegram_token"`
 	Users                         map[string]string `mapstructure:"slack_users"`
 	UserGroups                    map[string]string `mapstructure:"slack_usergroups"`

--- a/remote/gchat/helper.go
+++ b/remote/gchat/helper.go
@@ -29,9 +29,10 @@ type DomainEvent struct {
 // HandleOutput handles input messages for this remote.
 func HandleRemoteInput(inputMsgs chan<- models.Message, rules map[string]models.Rule, bot *models.Bot) {
 	c := &Client{
-		Credentials:    bot.GoogleChatCredentials,
-		ProjectID:      bot.GoogleChatProjectID,
-		SubscriptionID: bot.GoogleChatSubscriptionID,
+		Credentials:        bot.GoogleChatCredentials,
+		ProjectID:          bot.GoogleChatProjectID,
+		SubscriptionID:     bot.GoogleChatSubscriptionID,
+		ForceReplyToThread: bot.GoogleChatForceReplyToThread,
 	}
 
 	// Read messages from Google Chat
@@ -41,9 +42,10 @@ func HandleRemoteInput(inputMsgs chan<- models.Message, rules map[string]models.
 // HandleRemoteOutput handles output messages for this remote.
 func HandleRemoteOutput(message models.Message, bot *models.Bot) {
 	c := &Client{
-		Credentials:    bot.GoogleChatCredentials,
-		ProjectID:      bot.GoogleChatProjectID,
-		SubscriptionID: bot.GoogleChatSubscriptionID,
+		Credentials:        bot.GoogleChatCredentials,
+		ProjectID:          bot.GoogleChatProjectID,
+		SubscriptionID:     bot.GoogleChatSubscriptionID,
+		ForceReplyToThread: bot.GoogleChatForceReplyToThread,
 	}
 
 	// Send messages to Google Chat
@@ -77,11 +79,8 @@ func toMessage(m *pubsub.Message) (models.Message, error) {
 		message.ChannelID = event.Space.Name
 		message.BotMentioned = true // Google Chat only supports @bot mentions
 		message.DirectMessageOnly = event.Space.SingleUserBotDm
-
-		if event.Space.Threaded {
-			message.ThreadID = event.Message.Thread.Name
-			message.ThreadTimestamp = event.EventTime
-		}
+		message.ThreadID = event.Message.Thread.Name
+		message.ThreadTimestamp = event.EventTime
 
 		// make channel variables available
 		message.Vars["_channel.name"] = message.ChannelName // will be empty if it came via DM
@@ -95,6 +94,7 @@ func toMessage(m *pubsub.Message) (models.Message, error) {
 	if event.User != nil {
 		message.Vars["_user.name"] = event.User.DisplayName
 		message.Vars["_user.id"] = event.User.Name
+		message.Vars["_user.internal_id"] = event.User.Name
 		message.Vars["_user.displayname"] = event.User.DisplayName
 
 		// Try parsing as a domain message to get user email


### PR DESCRIPTION
## Proposed change

This patch introduces a enhancement to the bot functionality with Google Chat. It has been observed that Google Chat has ceased to provide the `event.Space.Threaded` value, leading to an issue where the bot could not determine whether a message was sent in a thread or directly to the group. As a result, the bot was defaulting to responding only in the group and never in a thread.

To resolve this issue, a new global configuration option,`google_chat_force_reply_to_thread`, has been added to the bot's settings. This boolean setting allows administrators to specify whether the bot should always reply within a thread if available or continue to respond in the group. The new setting ensures that the bot's replies are consistent with the desired conversation flow, enhancing the overall user interaction with the bot within Google Chat environments.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
